### PR TITLE
[WIP] Port service to Nats based CRUD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-*.gem
-coverage
-config.yml
+datacenter-store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.6.2-alpine
+
+RUN apk add --update git && apk add --update make && rm -rf /var/cache/apk/*
+
+ADD . /go/src/github.com/ernestio/datacenter-store
+WORKDIR /go/src/github.com/ernestio/datacenter-store
+
+RUN make deps && go install
+
+ENTRYPOINT ./entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,22 @@
-default: install
+install:
+	go install -v
 
-lint:
-	rubocop --fail-fast
+build:
+	go build -v ./...
 
-cover:
-	COVERAGE=true MIN_COVERAGE=50 bundle exec rspec -c -f d spec
+deps: dev-deps
+	go get -u github.com/jinzhu/gorm
+	go get -u github.com/nats-io/nats
+	go get -u github.com/lib/pq
+	go get -u github.com/r3labs/natsdb
+
+dev-deps:
+	go get -u github.com/golang/lint/golint
+	go get -u github.com/smartystreets/goconvey/convey
 
 test:
-	bundle exec rspec -f d spec
+	go test -v ./...
 
-install:
-	bundle install
-
-clean:
-	rm -rf coverage
+lint:
+	golint ./...
+	go vet ./...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Datacenter Store
 
-It manages all ernest datacenter storage through a public exposed Rest API
+It manages all ernest datacenter storage through a NATS api
 
 ## Build status
 
@@ -10,14 +10,32 @@ It manages all ernest datacenter storage through a public exposed Rest API
 ## Installation
 
 ```
+make deps
 make install
 ```
 
 ## Running Tests
 
 ```
+make deps
 make test
 ```
+
+## Endpoints
+
+You have available the nats endpoints:
+
+###datacenter.get
+It receives as input a valid datacenter with only the id or name as required fields. It returns a valid datacenter.
+
+###datacenter.del
+It receives as input a valid datacenter with only the id as required field. And it deletes the row if it can find it.
+
+###datacenter.set
+It receives as input a valid datacenter with id or not, and it will create or update the datacenter with the given fields.
+
+###datacenter.find
+It receives as input a valid datacenter, and it will do a search on the database with the given fields.
 
 ## Contributing
 
@@ -32,7 +50,7 @@ relevant unit tests.
 ## Versioning
 
 For transparency into our release cycle and in striving to maintain backward
-compatibility, this project is maintained under [the Semantic Versioning guidelines](http://semver.org/).
+compatibility, this project is maintained under [the Semantic Versioning guidelines](http://semver.org/). 
 
 ## Copyright and License
 

--- a/basic_test.go
+++ b/basic_test.go
@@ -147,10 +147,10 @@ func TestGetHandler(t *testing.T) {
 		Convey("Given datacenters exist on the database", func() {
 			createEntities(20)
 			Convey("Then I should get a list of datacenters", func() {
-				msg, _ := n.Request("datacenter.find", []byte(`{}`), time.Second)
+				msg, _ := n.Request("datacenter.find", []byte(`{"group_id":2}`), time.Second)
 				list := []Entity{}
 				json.Unmarshal(msg.Data, &list)
-				So(len(list), ShouldEqual, 20)
+				So(len(list), ShouldEqual, 1)
 			})
 		})
 	})

--- a/basic_test.go
+++ b/basic_test.go
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGetHandler(t *testing.T) {
+	setupNats()
+	n.Subscribe("config.get.postgres", func(msg *nats.Msg) {
+		n.Publish(msg.Reply, []byte(`{"names":["users","datacenters","datacenters","services"],"password":"","url":"postgres://postgres@127.0.0.1","user":""}`))
+	})
+	setupPg()
+	startHandler()
+
+	Convey("Scenario: getting a datacenter", t, func() {
+		setupTestSuite()
+		Convey("Given the datacenter does not exist on the database", func() {
+			msg, err := n.Request("datacenter.get", []byte(`{"id":"32"}`), time.Second)
+			So(string(msg.Data), ShouldEqual, string(handler.NotFoundErrorMessage))
+			So(err, ShouldEqual, nil)
+		})
+
+		Convey("Given the datacenter exists on the database", func() {
+			createEntities(1)
+			e := Entity{}
+			db.First(&e)
+			id := fmt.Sprint(e.ID)
+
+			msg, err := n.Request("datacenter.get", []byte(`{"id":`+id+`}`), time.Second)
+			output := Entity{}
+			json.Unmarshal(msg.Data, &output)
+			So(output.ID, ShouldEqual, e.ID)
+			So(output.Name, ShouldEqual, e.Name)
+			So(output.Type, ShouldEqual, e.Type)
+			So(output.Region, ShouldEqual, e.Region)
+			So(output.Username, ShouldEqual, e.Username)
+			So(output.Password, ShouldEqual, e.Password)
+			So(output.VCloudURL, ShouldEqual, e.VCloudURL)
+			So(output.VseURL, ShouldEqual, e.VseURL)
+			So(output.ExternalNetwork, ShouldEqual, e.ExternalNetwork)
+			So(err, ShouldEqual, nil)
+		})
+
+		Convey("Given the datacenter exists on the database and searching by name", func() {
+			createEntities(1)
+			e := Entity{}
+			db.First(&e)
+
+			msg, err := n.Request("datacenter.get", []byte(`{"name":"`+e.Name+`"}`), time.Second)
+			output := Entity{}
+			json.Unmarshal(msg.Data, &output)
+			So(output.ID, ShouldEqual, e.ID)
+			So(output.Name, ShouldEqual, e.Name)
+			So(output.Type, ShouldEqual, e.Type)
+			So(output.Region, ShouldEqual, e.Region)
+			So(output.Username, ShouldEqual, e.Username)
+			So(output.Password, ShouldEqual, e.Password)
+			So(output.VCloudURL, ShouldEqual, e.VCloudURL)
+			So(output.VseURL, ShouldEqual, e.VseURL)
+			So(output.ExternalNetwork, ShouldEqual, e.ExternalNetwork)
+			So(err, ShouldEqual, nil)
+		})
+	})
+
+	Convey("Scenario: deleting a datacenter", t, func() {
+		setupTestSuite()
+		Convey("Given the datacenter does not exist on the database", func() {
+			msg, err := n.Request("datacenter.del", []byte(`{"id":32}`), time.Second)
+			So(string(msg.Data), ShouldEqual, string(handler.NotFoundErrorMessage))
+			So(err, ShouldEqual, nil)
+		})
+
+		Convey("Given the datacenter exists on the database", func() {
+			createEntities(1)
+			last := Entity{}
+			db.First(&last)
+			id := fmt.Sprint(last.ID)
+
+			msg, err := n.Request("datacenter.del", []byte(`{"id":`+id+`}`), time.Second)
+			So(string(msg.Data), ShouldEqual, string(handler.DeletedMessage))
+			So(err, ShouldEqual, nil)
+
+			deleted := Entity{}
+			db.First(&deleted, id)
+			So(deleted.ID, ShouldEqual, 0)
+		})
+	})
+
+	Convey("Scenario: datacenter set", t, func() {
+		setupTestSuite()
+		Convey("Given we don't provide any id as part of the body", func() {
+			Convey("Then it should return the created record and it should be stored on DB", func() {
+				msg, err := n.Request("datacenter.set", []byte(`{"name":"fred"}`), time.Second)
+				output := Entity{}
+				output.LoadFromInput(msg.Data)
+				So(output.ID, ShouldNotEqual, nil)
+				So(output.Name, ShouldEqual, "fred")
+				So(err, ShouldEqual, nil)
+
+				stored := Entity{}
+				db.First(&stored, output.ID)
+				So(stored.Name, ShouldEqual, "fred")
+			})
+		})
+
+		Convey("Given we provide an unexisting id", func() {
+			Convey("Then we should receive a not found message", func() {
+				msg, err := n.Request("datacenter.set", []byte(`{"id": 1000, "name":"fred"}`), time.Second)
+				So(string(msg.Data), ShouldEqual, string(handler.NotFoundErrorMessage))
+				So(err, ShouldEqual, nil)
+			})
+		})
+
+		Convey("Given we provide an existing id", func() {
+			createEntities(1)
+			e := Entity{}
+			db.First(&e)
+			id := fmt.Sprint(e.ID)
+			Convey("Then we should receive an updated entity", func() {
+				msg, err := n.Request("datacenter.set", []byte(`{"id": `+id+`, "name":"fred"}`), time.Second)
+				output := Entity{}
+				output.LoadFromInput(msg.Data)
+				So(output.ID, ShouldNotEqual, nil)
+				So(output.Name, ShouldEqual, "fred")
+				So(err, ShouldEqual, nil)
+
+				stored := Entity{}
+				db.First(&stored, output.ID)
+				So(stored.Name, ShouldEqual, "fred")
+			})
+		})
+	})
+
+	Convey("Scenario: find datacenters", t, func() {
+		setupTestSuite()
+		Convey("Given datacenters exist on the database", func() {
+			createEntities(20)
+			Convey("Then I should get a list of datacenters", func() {
+				msg, _ := n.Request("datacenter.find", []byte(`{}`), time.Second)
+				list := []Entity{}
+				json.Unmarshal(msg.Data, &list)
+				So(len(list), ShouldEqual, 20)
+			})
+		})
+	})
+
+}

--- a/circle.yml
+++ b/circle.yml
@@ -1,18 +1,16 @@
 machine:
   services:
-    - postgresql
-    - redis
+    - docker
+  environment:
+    NATS_URI:  nats://127.0.0.1:4222
 
 dependencies:
   override:
-    - echo "CREATE DATABASE test_datacenters;" | psql -U postgres
-    - sudo mkdir -p /opt/ernest-libraries/authentication-middleware
-    - sudo chmod 777 /opt/ernest-libraries/authentication-middleware
-    - git clone git@github.com:ErnestIO/authentication-middleware.git /opt/ernest-libraries/authentication-middleware
-    - make install
+    - echo "CREATE DATABASE datacenters;" | psql -U postgres
+    - docker run -d -p 4222:4222 nats
+    - make deps
 
 test:
   override:
     - make test
     - make lint
-    - make cover

--- a/entity.go
+++ b/entity.go
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package main
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/nats-io/nats"
+	"github.com/r3labs/natsdb"
+)
+
+// Entity : the database mapped entity
+type Entity struct {
+	ID              uint   `json:"id" gorm:"primary_key"`
+	GroupID         uint   `json:"group_id" gorm:"unique_index:idx_per_group"`
+	Name            string `json:"name" gorm:"unique_index:idx_per_group"`
+	Type            string `json:"type" gorm:"unique_index:idx_per_group"`
+	Region          string `json:"region"`
+	Username        string `json:"username"`
+	Password        string `json:"password"`
+	VCloudURL       string `json:"vcloud_url"`
+	VseURL          string `json:"vse_url"`
+	ExternalNetwork string `json:"external_network"`
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+	DeletedAt       *time.Time `json:"-" sql:"index"`
+}
+
+// TableName : set Entity's table name to be datacenters
+func (Entity) TableName() string {
+	return "datacenters"
+}
+
+// Find : based on the defined fields for the current entity
+// will perform a search on the database
+func (e *Entity) Find() []interface{} {
+	entities := []Entity{}
+	db.Find(&entities)
+
+	list := make([]interface{}, len(entities))
+	for i, s := range entities {
+		list[i] = s
+	}
+
+	return list
+}
+
+// MapInput : maps the input []byte on the current entity
+func (e *Entity) MapInput(body []byte) {
+	json.Unmarshal(body, &e)
+}
+
+// HasID : determines if the current entity has an id or not
+func (e *Entity) HasID() bool {
+	if e.ID == 0 {
+		return false
+	}
+	return true
+}
+
+// LoadFromInput : Will load from a []byte input the database stored entity
+func (e *Entity) LoadFromInput(msg []byte) bool {
+	e.MapInput(msg)
+	var stored Entity
+	if e.ID != 0 {
+		db.First(&stored, e.ID)
+	} else if e.Name != "" {
+		db.Where("name = ?", e.Name).First(&stored)
+	}
+	if &stored == nil {
+		return false
+	}
+	if ok := stored.HasID(); !ok {
+		return false
+	}
+	e.Name = stored.Name
+	e.ID = stored.ID
+
+	return true
+}
+
+// LoadFromInputOrFail : Will try to load from the input an existing entity,
+// or will call the handler to Fail the nats message
+func (e *Entity) LoadFromInputOrFail(msg *nats.Msg, h *natsdb.Handler) bool {
+	stored := &Entity{}
+	ok := stored.LoadFromInput(msg.Data)
+	if !ok {
+		h.Fail(msg)
+	}
+	*e = *stored
+
+	return ok
+}
+
+// Update : It will update the current entity with the input []byte
+func (e *Entity) Update(body []byte) {
+	e.MapInput(body)
+	stored := Entity{}
+	db.First(&stored, e.ID)
+	stored.Name = e.Name
+
+	db.Save(&stored)
+	e = &stored
+}
+
+// Delete : Will delete from database the current Entity
+func (e *Entity) Delete() {
+	db.Unscoped().Delete(&e)
+}
+
+// Save : Persists current entity on database
+func (e *Entity) Save() {
+	db.Save(&e)
+}

--- a/entity.go
+++ b/entity.go
@@ -96,7 +96,7 @@ func (e *Entity) LoadFromInputOrFail(msg *nats.Msg, h *natsdb.Handler) bool {
 }
 
 // Update : It will update the current entity with the input []byte
-func (e *Entity) Update(body []byte) {
+func (e *Entity) Update(body []byte) error {
 	e.MapInput(body)
 	stored := Entity{}
 	db.First(&stored, e.ID)
@@ -104,14 +104,20 @@ func (e *Entity) Update(body []byte) {
 
 	db.Save(&stored)
 	e = &stored
+
+	return nil
 }
 
 // Delete : Will delete from database the current Entity
-func (e *Entity) Delete() {
+func (e *Entity) Delete() error {
 	db.Unscoped().Delete(&e)
+
+	return nil
 }
 
 // Save : Persists current entity on database
-func (e *Entity) Save() {
+func (e *Entity) Save() error {
 	db.Save(&e)
+
+	return nil
 }

--- a/entity.go
+++ b/entity.go
@@ -38,7 +38,15 @@ func (Entity) TableName() string {
 // will perform a search on the database
 func (e *Entity) Find() []interface{} {
 	entities := []Entity{}
-	db.Find(&entities)
+	if e.Name != "" && e.GroupID != 0 {
+		db.Where("name = ?", e.Name).Where("group_id = ?", e.GroupID).Find(&entities)
+	} else {
+		if e.Name != "" {
+			db.Where("name = ?", e.Name).Find(&entities)
+		} else if e.GroupID != 0 {
+			db.Where("group_id = ?", e.GroupID).Find(&entities)
+		}
+	}
 
 	list := make([]interface{}, len(entities))
 	for i, s := range entities {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+echo "Waiting for Postgres"
+while ! echo exit | nc postgres 5432; do sleep 1; done
+
+echo "Starting datacenter-store"
+/go/bin/datacenter-store

--- a/main.go
+++ b/main.go
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package main
+
+import (
+	"runtime"
+
+	"github.com/jinzhu/gorm"
+	"github.com/nats-io/nats"
+	"github.com/r3labs/natsdb"
+
+	_ "github.com/jinzhu/gorm/dialects/postgres"
+)
+
+var n *nats.Conn
+var db *gorm.DB
+var err error
+var handler natsdb.Handler
+
+func startHandler() {
+	handler = natsdb.Handler{
+		NotFoundErrorMessage:   []byte(`{"error":"not found"}`),
+		UnexpectedErrorMessage: []byte(`{"error":"unexpected"}`),
+		DeletedMessage:         []byte(`"deleted"`),
+		Nats:                   n,
+		NewModel: func() natsdb.Model {
+			return &Entity{}
+		},
+	}
+
+	n.Subscribe("datacenter.get", handler.Get)
+	n.Subscribe("datacenter.del", handler.Del)
+	n.Subscribe("datacenter.set", handler.Set)
+	n.Subscribe("datacenter.find", handler.Find)
+}
+
+func main() {
+	setupNats()
+	setupPg()
+	startHandler()
+
+	runtime.Goexit()
+}

--- a/setup.go
+++ b/setup.go
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/jinzhu/gorm"
+	"github.com/nats-io/nats"
+
+	_ "github.com/jinzhu/gorm/dialects/postgres"
+)
+
+// Sets up the nats client based on NATS_URI environment variable
+func setupNats() {
+	var natsURL = os.Getenv("NATS_URI")
+	n, err = nats.Connect(natsURL)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func setupPg() {
+	var cfg map[string]interface{}
+	resp, err := n.Request("config.get.postgres", nil, time.Second)
+	if err != nil {
+		log.Println("could not load config")
+		log.Panic(err)
+	}
+
+	err = json.Unmarshal(resp.Data, &cfg)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	pgURL := fmt.Sprintf("%s/%s?sslmode=disable", cfg["url"], "datacenters")
+	db, err = gorm.Open("postgres", pgURL)
+	if err != nil {
+		panic(err)
+	}
+	db.AutoMigrate(&Entity{})
+}

--- a/support_test.go
+++ b/support_test.go
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package main
+
+import (
+	"strconv"
+)
+
+func setupTestSuite() {
+	db.Where("true = true").Unscoped().Delete(Entity{})
+}
+
+func createEntities(n int) {
+	i := 0
+	for i < n {
+		x := strconv.Itoa(i)
+		db.Create(&Entity{Name: "Test" + x})
+		i++
+	}
+}

--- a/support_test.go
+++ b/support_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func setupTestSuite() {
-	db.Where("true = true").Unscoped().Delete(Entity{})
+	db.Unscoped().Delete(Entity{})
 }
 
 func createEntities(n int) {
 	i := 0
 	for i < n {
 		x := strconv.Itoa(i)
-		db.Create(&Entity{Name: "Test" + x})
+		db.Create(&Entity{Name: "Test" + x, GroupID: uint(i)})
 		i++
 	}
 }


### PR DESCRIPTION
This is a port to go + postgres for current datacenter-store, it will serve as a "crud" for "datacenters" while we remove the public rest api that will be managed by a dedicated api-gateway. 

It will be exporting a nats public api so you can query it through the endpoints bellow:

### datacenter.get
Will return a json representation of a datacenter based on the given datacenter id.
```
# Received message
{ "id": "<datacenter_id>" }
```

### datacenter.set
It will receive a json representation of a datacenter, and it will store it on postgres, in case you're providing an id it will update the record.
```
# Received message
{ "id": "<datacenter_id>", "name": "name".... }
````

### datacenter.del
It will remove a datacenter based on its id when it receives a json message like:
```
# Received message
{ "id": "<datacenter_id>" }
```

### datacenter.find
It allows you to find a specific datacenter by the given fields, example searching by name:
```
{ "name": "<datacenter_name>" }
``` 

This service will be consumed by the new api-gateway.